### PR TITLE
Added readonly property "BufferedWaveProvider" to WaveInProvider

### DIFF
--- a/NAudio.Core/Wave/WaveProviders/WaveInProvider.cs
+++ b/NAudio.Core/Wave/WaveProviders/WaveInProvider.cs
@@ -26,6 +26,17 @@
         }
 
         /// <summary>
+        /// Buffer provider that is storing buffers added by the source
+        /// </summary>
+        public BufferedWaveProvider BufferedWaveProvider
+        {
+            get
+            {
+                return this.bufferedWaveProvider;
+            }
+        }
+        
+        /// <summary>
         /// Reads data from the WaveInProvider
         /// </summary>
         public int Read(byte[] buffer, int offset, int count)


### PR DESCRIPTION
Currently there is no way to determine how many (if any) bytes have been added to the internal Buffer by the WaveInProvider.

This PR exposes the internal BufferedWaveProvider via a ReadOnly property so that consumers can determine how many bytes are available, as well as allowing control over the internal ReadFully property if required.